### PR TITLE
Ensure overlap uses Allen-Wald

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module goEEW
+
+go 1.23.8

--- a/mmi/mmi.go
+++ b/mmi/mmi.go
@@ -87,11 +87,11 @@ func AllenWald12(M, R float64) float64 {
 // directly.
 func BestEstimate(M, R float64) float64 {
 	switch {
+	case R > 20 && R < 30:
+		return AllenWald12(M, R)
 	case R <= 20:
 		return AtkinsonWald07(M, R)
-	case R >= 30:
-		return BakunWentworth97(M, R)
 	default:
-		return AllenWald12(M, R)
+		return BakunWentworth97(M, R)
 	}
 }

--- a/mmi/mmi_test.go
+++ b/mmi/mmi_test.go
@@ -1,0 +1,13 @@
+package mmi
+
+import "testing"
+
+func TestBestEstimateOverlapUsesAllenWald12(t *testing.T) {
+	m := 6.0
+	r := 25.0
+	want := AllenWald12(m, r)
+	got := BestEstimate(m, r)
+	if got != want {
+		t.Errorf("BestEstimate(%v,%v) = %v, want %v", m, r, got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- update the distance switch in `BestEstimate`
- add a go module
- verify that `BestEstimate` falls back to `AllenWald12` for overlapping ranges

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6848c91a5d54832fa7b751f66caf16d0